### PR TITLE
Add ChatTwo typing state integration via IPC

### DIFF
--- a/client/rtyping/ChatTwoIpc.cs
+++ b/client/rtyping/ChatTwoIpc.cs
@@ -1,0 +1,71 @@
+using System;
+using Dalamud.Plugin.Ipc;
+
+namespace rtyping
+{
+    // Mirrors ChatTwo.Code.ChatType (ushort-backed) — only needed for IPC type matching,
+    // values are never read by this plugin.
+    internal enum ChatTwoChannelType : ushort { }
+
+    internal sealed class ChatTwoIpc : IDisposable
+    {
+        private readonly Plugin Plugin;
+
+        private ICallGateSubscriber<object?>? _available;
+        private ICallGateSubscriber<(bool, bool, bool, bool, int, ChatTwoChannelType), object?>? _stateChanged;
+
+        internal ChatTwoIpc(Plugin plugin)
+        {
+            Plugin = plugin;
+
+            try
+            {
+                _available = Plugin.PluginInterface.GetIpcSubscriber<object?>("ChatTwo.Available");
+                _available.Subscribe(OnChatTwoAvailable);
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log.Warning(ex, "ChatTwo IPC: failed to subscribe to ChatTwo.Available");
+            }
+
+            TrySubscribeStateChanged();
+        }
+
+        private void TrySubscribeStateChanged()
+        {
+            try
+            {
+                _stateChanged = Plugin.PluginInterface
+                    .GetIpcSubscriber<(bool InputVisible, bool InputFocused, bool HasText, bool IsTyping, int TextLength, ChatTwoChannelType ChannelType), object?>(
+                        "ChatTwo.ChatInputStateChanged");
+                _stateChanged.Subscribe(OnStateChanged);
+
+                // Immediately sync state in case ChatTwo is already loaded and the user is typing.
+                var query = Plugin.PluginInterface
+                    .GetIpcSubscriber<(bool, bool, bool, bool, int, ChatTwoChannelType)>("ChatTwo.GetChatInputState");
+                var state = query.InvokeFunc();
+                Plugin.TypingManager.IPCTyping = state.Item4;
+            }
+            catch
+            {
+                // ChatTwo is not installed or not yet loaded — safe to ignore.
+            }
+        }
+
+        private void OnChatTwoAvailable() => TrySubscribeStateChanged();
+
+        private void OnStateChanged((bool InputVisible, bool InputFocused, bool HasText, bool IsTyping, int TextLength, ChatTwoChannelType ChannelType) state)
+        {
+            Plugin.TypingManager.IPCTyping = state.IsTyping;
+        }
+
+        public void Dispose()
+        {
+            try { _available?.Unsubscribe(OnChatTwoAvailable); } catch { }
+            try { _stateChanged?.Unsubscribe(OnStateChanged); } catch { }
+
+            // Clear the override so vanilla detection takes back over cleanly.
+            Plugin.TypingManager.IPCTyping = false;
+        }
+    }
+}

--- a/client/rtyping/Plugin.cs
+++ b/client/rtyping/Plugin.cs
@@ -44,6 +44,7 @@ namespace rtyping
         public ContextMenuManager ContextMenuManager { get; init; }
         public WindowSystem WindowSystem = new("rtyping");
         public IpcController IPCController;
+        internal ChatTwoIpc ChatTwoIpc { get; private set; } = null!;
 
         public PartyTypingUI PartyTypingUI;
         public ConfigWindow ConfigWindow;
@@ -67,6 +68,7 @@ namespace rtyping
             this.PartyManager = new PartyManager(this);
             this.ContextMenuManager = new ContextMenuManager(this);
             this.IPCController = new IpcController(this);
+            this.ChatTwoIpc = new ChatTwoIpc(this);
 
             this.TrustedCharacterDb = new TrustedCharacterContext(PluginInterface.GetPluginConfigDirectory() + Path.DirectorySeparatorChar);
 
@@ -119,6 +121,7 @@ namespace rtyping
         public void Dispose()
         {
             WindowSystem.RemoveAllWindows();
+            ChatTwoIpc.Dispose();
             IPCController.Dispose();
             this.Client.Dispose();
             this.ContextMenuManager.Dispose();

--- a/client/rtyping/TypingManager.cs
+++ b/client/rtyping/TypingManager.cs
@@ -101,7 +101,7 @@ namespace rtyping
             }
 
             if (Environment.TickCount64 < ResendDelay) return;
-            if (IPCTyping) return;
+            if (IPCTyping) { WasTyping = false; return; } // reset so next frame re-triggers start-typing broadcast
 
             var currentChat = GetChatString();
 


### PR DESCRIPTION
Subscribes to ChatTwo's ChatInputStateChanged IPC event so that typing activity in ChatTwo's input box is detected and broadcast to party members, the same as vanilla chat. Falls back to vanilla detection automatically when ChatTwo is not installed.

Also fixes a resend bug where IPCTyping=true would suppress the 15-second keepalive broadcast, causing recipients' typing indicators to expire silently.